### PR TITLE
Cache only GET requests in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -80,11 +80,11 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // All other requests: try network first, then cache
+  // All other requests: try network first, then cache GET requests
   event.respondWith(
     fetch(request)
       .then((networkResponse) => {
-        if (networkResponse && networkResponse.ok) {
+        if (networkResponse && networkResponse.ok && request.method === 'GET') {
           const clone = networkResponse.clone();
           caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
         }


### PR DESCRIPTION
## Summary
- Only store GET responses in cache for non-navigate requests
- Clarify comment that only GET requests are cached

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68996b4cbeb4832cad6874905cc3c2ae